### PR TITLE
Allow for legacy order submit

### DIFF
--- a/src/viur/datastore/query.py
+++ b/src/viur/datastore/query.py
@@ -294,8 +294,8 @@ class Query(object):
 			if isinstance(order, str):
 				order = (order, SortOrder.Ascending)
 
-			assert isinstance(order[0], str) and isinstance(order[1], SortOrder), \
-				f"Invalid ordering {order}, it has to be a tuple. Try: `(\"{order}\", SortOrder.Ascending)`"
+			if not (isinstance(order[0], str) and isinstance(order[1], SortOrder)):
+				raise TypeError(f"Invalid ordering {order}, it has to be a tuple. Try: `(\"{order}\", SortOrder.Ascending)`")
 
 			orders.append(order)
 

--- a/src/viur/datastore/query.py
+++ b/src/viur/datastore/query.py
@@ -287,6 +287,20 @@ class Query(object):
 		if self.queries is None:
 			# This Query is unsatisfiable - don't try to bother
 			return self
+
+		# Check for correct order subscript
+		orders = []
+		for order in orderings:
+			if isinstance(order, str):
+				order = (order, SortOrder.Ascending)
+
+			assert isinstance(order[0], str) and isinstance(order[1], SortOrder), \
+				f"Invalid ordering {order}, it has to be a tuple. Try: `(\"{order}\", SortOrder.Ascending)`"
+
+			orders.append(order)
+
+		orderings = tuple(orders)
+
 		if self._orderHook is not None:
 			try:
 				orderings = self._orderHook(self, orderings)
@@ -295,11 +309,13 @@ class Query(object):
 				return self
 			if orderings is None:
 				return self
+
 		if isinstance(self.queries, list):
 			for query in self.queries:
 				query.orders = list(orderings)
 		else:
 			self.queries.orders = list(orderings)
+
 		return self
 
 	def setCursor(self, startCursor: str, endCursor: Optional[str] = None) -> 'Query':


### PR DESCRIPTION
ViUR2 allowed to specify `query.order("name")`. ViUR3 expects this to be `query.order(("name", db.SortOrder.Ascending))`. This fix allows for either the old or the new method, and also checks for correct parametrization.