### PR TITLE
Include 100 in limit range in fetch()

### DIFF
--- a/src/viur/datastore/query.py
+++ b/src/viur/datastore/query.py
@@ -577,7 +577,7 @@ class Query(object):
 		if self.srcSkel is None:
 			raise NotImplementedError("This query has not been created using skel.all()")
 		# limit = limit if limit != -1 else self._limit
-		if limit != -1 and not (0 < limit < 100):
+		if limit != -1 and not (0 < limit <= 100):
 			logging.error(("Limit", limit))
 			raise NotImplementedError(
 				"This query is not limited! You must specify an upper bound using limit() between 1 and 100")


### PR DESCRIPTION
In ViUR2 a max. fetch limit of 100 was allowed (https://github.com/viur-framework/server/blob/e53c744834103a467a5f51b6b29db7aa531a6096/db.py#L858)
Now, in ViUR3, we allow max. 99, but still say _"limit() [must be] between 1 and 100"_:
https://github.com/viur-framework/viur-datastore/blob/1487d5a0b96396969f03796862d78ebd05b37f9e/src/viur/datastore/query.py#L583

I think this should be including, otherwise the 1 wouldn't be in this interval too.