### PR TITLE
Fix/keyhelperfix

### DIFF
--- a/src/viur/datastore/utils.py
+++ b/src/viur/datastore/utils.py
@@ -55,6 +55,7 @@ def normalizeKey(key: Union[None, 'db.KeyClass']) -> Union[None, 'db.KeyClass']:
 def keyHelper(inKey: Union[Key, str, int], targetKind: str,
 			  additionalAllowedKinds: Union[None, List[str]] = None) -> Key:
 	if isinstance(inKey, str):
+		inKey = inKey.strip()
 		try:
 			decodedKey = normalizeKey(Key.from_legacy_urlsafe(inKey))
 		except:

--- a/src/viur/datastore/utils.py
+++ b/src/viur/datastore/utils.py
@@ -53,14 +53,14 @@ def normalizeKey(key: Union[None, 'db.KeyClass']) -> Union[None, 'db.KeyClass']:
 
 
 def keyHelper(inKey: Union[Key, str, int], targetKind: str,
-			  additionalAllowdKinds: Union[None, List[str]] = None) -> Key:
+			  additionalAllowedKinds: Union[None, List[str]] = None) -> Key:
 	if isinstance(inKey, str):
 		try:
 			decodedKey = normalizeKey(Key.from_legacy_urlsafe(inKey))
 		except:
 			decodedKey = None
 		if decodedKey:  # If it did decode, don't try any further
-			if decodedKey.kind != targetKind and (not additionalAllowdKinds or inKey.kind not in additionalAllowdKinds):
+			if decodedKey.kind != targetKind and (not additionalAllowedKinds or decodedKey.kind not in additionalAllowedKinds):
 				raise ValueError("Kin1d mismatch: %s != %s" % (decodedKey.kind, targetKind))
 			return decodedKey
 		if inKey.isdigit():
@@ -69,8 +69,8 @@ def keyHelper(inKey: Union[Key, str, int], targetKind: str,
 	elif isinstance(inKey, int):
 		return Key(targetKind, inKey)
 	elif isinstance(inKey, Key):
-		if inKey.kind != targetKind and (not additionalAllowdKinds or inKey.kind not in additionalAllowdKinds):
-			raise ValueError("Kin1d mismatch: %s != %s (%s)" % (inKey.kind, targetKind, additionalAllowdKinds))
+		if inKey.kind != targetKind and (not additionalAllowedKinds or inKey.kind not in additionalAllowedKinds):
+			raise ValueError("Kin1d mismatch: %s != %s (%s)" % (inKey.kind, targetKind, additionalAllowedKinds))
 		return inKey
 	else:
 		raise ValueError("Unknown key type %r" % type(inKey))

--- a/src/viur/datastore/utils.py
+++ b/src/viur/datastore/utils.py
@@ -55,7 +55,6 @@ def normalizeKey(key: Union[None, 'db.KeyClass']) -> Union[None, 'db.KeyClass']:
 def keyHelper(inKey: Union[Key, str, int], targetKind: str,
 			  additionalAllowedKinds: Union[None, List[str]] = None) -> Key:
 	if isinstance(inKey, str):
-		inKey = inKey.strip()
 		try:
 			decodedKey = normalizeKey(Key.from_legacy_urlsafe(inKey))
 		except:


### PR DESCRIPTION
Implementation of phorwards issues: https://github.com/viur-framework/viur-datastore/issues/12, https://github.com/viur-framework/viur-datastore/issues/11

This includes:
renaming: additionalAllowdKinds > additionalAllowedKinds
str keys now work with different targetKinds
ensures that a str key does not start and end with spaces