### PR TITLE
Provide Key.__str__() function again

### DIFF
--- a/src/viur/datastore/types.py
+++ b/src/viur/datastore/types.py
@@ -84,6 +84,9 @@ class Key:
 		"""
 		return self.id or self.name
 
+	def __str__(self):
+		return self.to_legacy_urlsafe().decode("ASCII")
+
 	def __repr__(self):
 		return "<viur.datastore.Key %s/%s, parent=%s>" % (self.kind, self.id_or_name, self.parent)
 

--- a/src/viur/datastore/utils.py
+++ b/src/viur/datastore/utils.py
@@ -106,7 +106,8 @@ def encodeKey(key: Key) -> str:
 	"""
 		Return the given key encoded as string (mimicking the old str() behaviour of keys)
 	"""
-	return key.to_legacy_urlsafe().decode("ASCII")
+	# todo: Should we make a deprecation warning when this function is used?
+	return str(key)
 
 def acquireTransactionSuccessMarker() -> str:
 	"""


### PR DESCRIPTION
We could discuss if `db.encodeKey()` should be marked as deprecated.