### PR TITLE
Quarantee `exclude_from_indexes` is a set

### DIFF
--- a/src/viur/datastore/types.py
+++ b/src/viur/datastore/types.py
@@ -154,11 +154,12 @@ class Entity(dict):
 	"""
 	__slots__ = ["key", "exclude_from_indexes", "version"]
 
-	def __init__(self, key: Optional[Key] = None, exclude_from_indexes: Optional[Tuple] = None):
+	def __init__(self, key: Optional[Key] = None, exclude_from_indexes: Optional[Set[str]] = None):
 		super(Entity, self).__init__()
 		assert not key or isinstance(key, Key), "Key must be a Key-Object (or None for an embedded entity)"
 		self.key = key
 		self.exclude_from_indexes = exclude_from_indexes or set()
+		assert isinstance(self.exclude_from_indexes, set)
 		self.version = None
 
 


### PR DESCRIPTION
- The old type annotation requested for a tuple, which is immutable
- The assert quarantees that `exclude_from_indexes` is a set
- This allows to used `exclude_from_indexes.add()` and `exclude_from_indexes.discard()` without previous key look-up (which is often the case in bone code of viur-core)