### PR TITLE
fix to_legacy_urlsafe

### DIFF
--- a/src/viur/datastore/types.py
+++ b/src/viur/datastore/types.py
@@ -111,7 +111,7 @@ class Key:
 				id=currentKey.id,
 				name=currentKey.name,
 			))
-			currentKey = self.parent
+			currentKey = currentKey.parent
 		reference = _app_engine_key_pb2.Reference(
 			app=projectID,
 			path=_app_engine_key_pb2.Path(element=pathElements),


### PR DESCRIPTION
This PR fix the probelm in `to_legacy_urlsafe` that the `currentKey = self.parent` get allways the parent form the orginal key not from the parent.