### PR TITLE
Improving Query.get_orders()

### DIFF
--- a/src/viur/datastore/query.py
+++ b/src/viur/datastore/query.py
@@ -407,13 +407,17 @@ class Query(object):
 
 			:returns: The orders form this query as a list if there is no orders set it returns None
 		"""
-		if isinstance(self.queries, QueryDefinition):
-			q = self.queries
-		elif isinstance(self.queries, list):
-			q = self.queries[0]
-		else:
-			raise f"self.queries can only be from type 'QueryDefinition' or a list of 'QueryDefinition'"
-		return q.orders if q.orders else None
+		q = self.queries
+
+		if isinstance(q, (list, tuple)):
+			q = q[0]
+
+		if not isinstance(q, QueryDefinition):
+			raise ValueError(
+				f"self.queries can only be a 'QueryDefinition' or a list of, but found {self.queries!r}"
+			)
+
+		return q.orders or None
 
 	def getKind(self) -> str:
 		"""


### PR DESCRIPTION
I came across this "nice" and very helpful exception that simply doesn't help anything:
```
Traceback (most recent call last):
  File "~/.local/share/virtualenvs/xyz-viur3-YEqVFfTR/lib/python3.10/site-packages/viur/core/request.py", line 269, in processRequest
    self.findAndCall(path)
  File "~/.local/share/virtualenvs/xyz-viur3-YEqVFfTR/lib/python3.10/site-packages/viur/core/request.py", line 608, in findAndCall
    res = caller(*newArgs, **newKwargs)
  File "~/xyz-viur3/deploy/duschtec/abstracts/groupedlist.py", line 214, in list
    return self.render.list(res)
  File "~/.local/share/virtualenvs/xyz-viur3-YEqVFfTR/lib/python3.10/site-packages/viur/core/render/json/default.py", line 259, in list
    res["orders"] = skellist.get_orders()
  File "~/.local/share/virtualenvs/xyz-viur3-YEqVFfTR/lib/python3.10/site-packages/viur/datastore/query.py", line 635, in <lambda>
    res.get_orders = lambda: self.get_orders()
  File "~/.local/share/virtualenvs/xyz-viur3-YEqVFfTR/lib/python3.10/site-packages/viur/datastore/query.py", line 415, in get_orders
    raise f"self.queries can only be from type 'QueryDefinition' or a list of 'QueryDefinition'"
TypeError: exceptions must derive from BaseException
```
So this PR...

- Cleans up code
- Fixed invalid str raise...

Please merge.