### PR TITLE
Improving keyHelper function

### DIFF
--- a/src/viur/datastore/utils.py
+++ b/src/viur/datastore/utils.py
@@ -59,7 +59,7 @@ def keyHelper(inKey: Union[Key, str, int], targetKind: str,
 		if inKey.kind != targetKind and inKey.kind not in additionalAllowedKinds:
 			if not adjust_kind:
 				raise ValueError(f"Kind mismatch: {inKey.kind!r} != {targetKind!r} (or in {additionalAllowedKinds!r})")
-			decodedKey.kind = targetKind
+			inKey.kind = targetKind
 		return inKey
 	elif isinstance(inKey, str):
 		# Try to parse key from str

--- a/src/viur/datastore/utils.py
+++ b/src/viur/datastore/utils.py
@@ -53,8 +53,8 @@ def normalizeKey(key: Union[None, 'db.KeyClass']) -> Union[None, 'db.KeyClass']:
 
 
 def keyHelper(inKey: Union[Key, str, int], targetKind: str,
-			  additionalAllowedKinds: Union[None, List[str], Tuple[str]] = (),
-              adjust_kind: bool = False) -> Key:
+			  additionalAllowedKinds: Union[List[str], Tuple[str]] = (),
+			  adjust_kind: bool = False) -> Key:
 	if isinstance(inKey, Key):
 		if inKey.kind != targetKind and inKey.kind not in additionalAllowedKinds:
 			if not adjust_kind:


### PR DESCRIPTION
- Fixes ValueError raise to f-string
- Raise NotImplementedError on unsupported key type
- Call recursively with decoded key based on a string to implement target kind checking once
- `adjust_kind`-parameter to optionally allow to adjust invalid kind to the target kind; This is useful when rewriting keys is explicitly wanted.
- Moved `isinstance(inKey, Key)` test to top, as this should be the usual case