### PR TITLE
Feature/memcache

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from Cython.Distutils import build_ext
 
 setup(
 	name='viur-datastore',
-	version="1.3.9",
+	version="1.3.10",
 	author="Tobias Steinrücken, Stefan Kögl",
 	author_email="devs@viur.dev",
 	maintainer="Stefan Kögl",
@@ -18,7 +18,6 @@ setup(
 	python_requires=">=3.10",
 	cmdclass={'build_ext': build_ext},
 	ext_modules=cythonize([Extension("viur.datastore.transport", ["src/viur/datastore/transport.pyx"], language="c++", extra_compile_args=["-std=c++11"])]),
-	install_requires=["appengine-python-standard"],
 	classifiers=[
 		"Programming Language :: Python :: 3",
 		"Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
 	python_requires=">=3.10",
 	cmdclass={'build_ext': build_ext},
 	ext_modules=cythonize([Extension("viur.datastore.transport", ["src/viur/datastore/transport.pyx"], language="c++", extra_compile_args=["-std=c++11"])]),
+	install_requires=["appengine-python-standard"],
 	classifiers=[
 		"Programming Language :: Python :: 3",
 		"Development Status :: 5 - Production/Stable",

--- a/src/viur/datastore/__init__.py
+++ b/src/viur/datastore/__init__.py
@@ -1,5 +1,6 @@
 from viur.datastore.config import conf as config
 from viur.datastore.errors import *
+from viur.datastore.cache import cache
 from viur.datastore.query import Query
 from viur.datastore.transport import AllocateIDs, Delete, Get, Put, RunInTransaction, Count
 from viur.datastore.types import (

--- a/src/viur/datastore/__init__.py
+++ b/src/viur/datastore/__init__.py
@@ -71,5 +71,5 @@ __all__ = [
 	"UnavailableError",
 	"NoMutationResultsError",
 	"is_viur_datastore_request_ok",
-	"cache"
+	"cache",
 ]

--- a/src/viur/datastore/__init__.py
+++ b/src/viur/datastore/__init__.py
@@ -1,6 +1,6 @@
 from viur.datastore.config import conf as config
 from viur.datastore.errors import *
-from viur.datastore.cache import cache
+from viur.datastore import cache
 from viur.datastore.query import Query
 from viur.datastore.transport import AllocateIDs, Delete, Get, Put, RunInTransaction, Count
 from viur.datastore.types import (
@@ -71,4 +71,5 @@ __all__ = [
 	"UnavailableError",
 	"NoMutationResultsError",
 	"is_viur_datastore_request_ok",
+	"cache"
 ]

--- a/src/viur/datastore/cache.py
+++ b/src/viur/datastore/cache.py
@@ -1,21 +1,57 @@
+import sys
 from typing import Dict, List, Union
 
-from google.appengine.api import memcache
+from viur.datastore.config import conf
+from viur.datastore.types import Entity, Key
 
-class Cache:
-	_memcache_max_batch_size = 30
-	_memcache_namespace = "viur-datastore"
-	_memcache_timeout = 60 * 60
-	_memcache_max_size = 1_000_000
-
-	def __init__(self):
-		self.client = memcache.Client()
-
-	def get(self, keys: Union[str, List[str]]):
-		return self.client.get_multi(keys, namespace=self._memcache_namespace)
-
-	def put(self, cache_data: Dict):
-		self.client.set_multi(cache_data, namespace=self._memcache_namespace, time=self._memcache_timeout)
+memcache_max_batch_size = 30
+memcache_namespace = "viur-datastore"
+memcache_timeout = 60 * 60
+memcache_max_size = 1_000_000
 
 
-cache = Cache()
+def get(keys: Union[str, Key, List[str], List[Key]]):
+	if not isinstance(keys, list):
+		keys = [keys]
+	keys = [str(key) for key in keys]  # Enforce that all keys are strings
+	res = {}
+
+	while keys:
+		res |= conf["memcache_client"].get_multi(keys[:memcache_max_batch_size], namespace=memcache_namespace)
+		keys = keys[memcache_max_batch_size:]
+	return res
+
+
+def set(cache_data: Union[Dict, List[Entity]]):
+	if isinstance(cache_data, dict):
+		# Add only values to cache <= memcache_max_size (1.000.000)
+		cache_data = {str(key): value for key, value in cache_data.items() if get_size(value) <= memcache_max_size}
+	elif isinstance(cache_data, list):
+		# Add only values to cache <= memcache_max_size (1.000.000)
+		cache_data = {str(item.key): item for item in cache_data if get_size(item) <= memcache_max_size}
+	keys = list(cache_data.keys())
+	while keys:
+		data = {key: cache_data[key] for key in keys[:memcache_max_batch_size]}
+		conf["memcache_client"].set_multi(data, namespace=memcache_namespace, time=memcache_timeout)
+		keys = keys[memcache_max_batch_size:]
+
+
+def delete(keys: Union[str, Key, List[str], List[Key]]):
+	if not isinstance(keys, list):
+		keys = [keys]
+	keys = [str(key) for key in keys]  # Enforce that all keys are strings
+	while keys:
+		conf["memcache_client"].delete_multi(keys[:memcache_max_batch_size], namespace=memcache_namespace)
+		keys = keys[memcache_max_batch_size:]
+
+
+def get_size(obj):
+	"""
+		Count the size of an object
+	"""
+	if isinstance(obj, dict):
+		return sum([get_size([k, v]) for k, v in obj.items()])
+	elif isinstance(obj, list):
+		return sum([get_size(x) for x in obj])
+
+	return sys.getsizeof(obj)

--- a/src/viur/datastore/cache.py
+++ b/src/viur/datastore/cache.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Dict, List, Union
+from typing import Any, Dict, List, Union
 
 from viur.datastore.config import conf
 from viur.datastore.types import Entity, Key
@@ -45,9 +45,9 @@ def delete(keys: Union[str, Key, List[str], List[Key]]):
 		keys = keys[memcache_max_batch_size:]
 
 
-def get_size(obj):
+def get_size(obj: Any) -> int:
 	"""
-		Count the size of an object
+		Utility function that counts the size of an object in bytes.
 	"""
 	if isinstance(obj, dict):
 		return sum([get_size([k, v]) for k, v in obj.items()])

--- a/src/viur/datastore/cache.py
+++ b/src/viur/datastore/cache.py
@@ -21,7 +21,6 @@ MEMCACHE_MAX_SIZE = 1_000_000
 	if not conf["viur.instance.is_dev_server"]:
 		from google.appengine.api.memcache import Client
 		from viur.core import db
-		db.config["use_memcache_client"] = True
 		db.config["memcache_client"] = Client()
 
 """

--- a/src/viur/datastore/cache.py
+++ b/src/viur/datastore/cache.py
@@ -1,0 +1,21 @@
+from typing import Dict, List, Union
+
+from google.appengine.api import memcache
+
+class Cache:
+	_memcache_max_batch_size = 30
+	_memcache_namespace = "viur-datastore"
+	_memcache_timeout = 60 * 60
+	_memcache_max_size = 1_000_000
+
+	def __init__(self):
+		self.client = memcache.Client()
+
+	def get(self, keys: Union[str, List[str]]):
+		return self.client.get_multi(keys, namespace=self._memcache_namespace)
+
+	def put(self, cache_data: Dict):
+		self.client.set_multi(cache_data, namespace=self._memcache_namespace, time=self._memcache_timeout)
+
+
+cache = Cache()

--- a/src/viur/datastore/cache.py
+++ b/src/viur/datastore/cache.py
@@ -4,13 +4,13 @@ from typing import Any, Dict, List, Union
 from viur.datastore.config import conf
 from viur.datastore.types import Entity, Key
 
-memcache_max_batch_size = 30
-memcache_namespace = "viur-datastore"
-memcache_timeout = 60 * 60
-memcache_max_size = 1_000_000
+MEMCACHE_MAX_BATCH_SIZE = 30
+MEMCACHE_NAMESPACE = "viur-datastore"
+MEMCACHE_TIMEOUT = 60 * 60
+MEMCACHE_MAX_SIZE = 1_000_000
 
 
-def get(keys: Union[str, Key, List[str], List[Key]]):
+def get(keys: Union[str, Key, List[str], List[Key]]) -> dict:
 	if not isinstance(keys, list):
 		keys = [keys]
 	keys = [str(key) for key in keys]  # Enforce that all keys are strings
@@ -36,7 +36,7 @@ def set(cache_data: Union[Dict, List[Entity]]):
 		keys = keys[memcache_max_batch_size:]
 
 
-def delete(keys: Union[str, Key, List[str], List[Key]]):
+def delete(keys: Union[str, Key, List[str], List[Key]]) -> None:
 	if not isinstance(keys, list):
 		keys = [keys]
 	keys = [str(key) for key in keys]  # Enforce that all keys are strings
@@ -50,8 +50,8 @@ def get_size(obj: Any) -> int:
 		Utility function that counts the size of an object in bytes.
 	"""
 	if isinstance(obj, dict):
-		return sum([get_size([k, v]) for k, v in obj.items()])
+		return sum(get_size([k, v]) for k, v in obj.items())
 	elif isinstance(obj, list):
-		return sum([get_size(x) for x in obj])
+		return sum(get_size(x) for x in obj)
 
 	return sys.getsizeof(obj)

--- a/src/viur/datastore/cache.py
+++ b/src/viur/datastore/cache.py
@@ -1,3 +1,4 @@
+import pprint
 import sys
 from typing import Any, Dict, List, Union
 
@@ -10,15 +11,41 @@ MEMCACHE_TIMEOUT = 60 * 60
 MEMCACHE_MAX_SIZE = 1_000_000
 
 
+"""
+
+	This Module controls the Interaction with the Memcache from Google
+	To activate the cache copy this code in your main.py
+	..  code-block:: python
+	# Example
+
+	if not conf["viur.instance.is_dev_server"]:
+		from google.appengine.api.memcache import Client
+		from viur.core import db
+		db.config["use_memcache_client"] = True
+		db.config["memcache_client"] = Client()
+
+"""
+
+__all__ = [
+"MEMCACHE_MAX_BATCH_SIZE",
+"MEMCACHE_NAMESPACE",
+"MEMCACHE_TIMEOUT",
+"MEMCACHE_MAX_SIZE",
+"get",
+"set",
+"delete",
+]
+
 def get(keys: Union[str, Key, List[str], List[Key]]) -> dict:
 	if not isinstance(keys, list):
 		keys = [keys]
 	keys = [str(key) for key in keys]  # Enforce that all keys are strings
 	res = {}
-
+	pprint.pprint(f"try get {keys=}")
 	while keys:
 		res |= conf["memcache_client"].get_multi(keys[:MEMCACHE_MAX_BATCH_SIZE], namespace=MEMCACHE_NAMESPACE)
 		keys = keys[MEMCACHE_MAX_BATCH_SIZE:]
+	pprint.pprint(f"get {res=}")
 	return res
 
 
@@ -33,6 +60,7 @@ def set(cache_data: Union[Entity, Dict[Key, Entity], List[Entity]]):
 	cache_data = {str(key): value for key, value in cache_data.items() if get_size(value) <= MEMCACHE_MAX_SIZE}
 
 	keys = list(cache_data.keys())
+	pprint.pprint(f"set  {keys=}")
 	while keys:
 		data = {key: cache_data[key] for key in keys[:MEMCACHE_MAX_BATCH_SIZE]}
 		conf["memcache_client"].set_multi(data, namespace=MEMCACHE_NAMESPACE, time=MEMCACHE_TIMEOUT)

--- a/src/viur/datastore/config.py
+++ b/src/viur/datastore/config.py
@@ -23,5 +23,5 @@ conf = {
 		"UNAUTHENTICATED",
 		"UNAVAILABLE"
 	},
-	"use_memcache_client": True,
+	"use_memcache_client": False,
 }

--- a/src/viur/datastore/config.py
+++ b/src/viur/datastore/config.py
@@ -24,4 +24,5 @@ conf = {
 		"UNAVAILABLE"
 	},
 	"use_memcache_client": False,
+	"memcache_client": None,
 }

--- a/src/viur/datastore/config.py
+++ b/src/viur/datastore/config.py
@@ -23,8 +23,6 @@ conf = {
 		"UNAUTHENTICATED",
 		"UNAVAILABLE"
 	},
-	# Set this to 'True' and the viur data store will cache the reads and writes.
-	"use_memcache_client": False,
 	# A Client form the Google Memcache Library.
 	"memcache_client": None,
 }

--- a/src/viur/datastore/config.py
+++ b/src/viur/datastore/config.py
@@ -22,5 +22,7 @@ conf = {
 		"RESOURCE_EXHAUSTED",
 		"UNAUTHENTICATED",
 		"UNAVAILABLE"
-	}
+	},
+	"memcache_client": None,
+	"use_memcache_client": False,
 }

--- a/src/viur/datastore/config.py
+++ b/src/viur/datastore/config.py
@@ -23,6 +23,8 @@ conf = {
 		"UNAUTHENTICATED",
 		"UNAVAILABLE"
 	},
+	# Set this to 'True' and the viur data store will cache the reads and writes.
 	"use_memcache_client": False,
+	# A Client form the Google Memcache Library.
 	"memcache_client": None,
 }

--- a/src/viur/datastore/config.py
+++ b/src/viur/datastore/config.py
@@ -23,6 +23,5 @@ conf = {
 		"UNAUTHENTICATED",
 		"UNAVAILABLE"
 	},
-	"memcache_client": None,
-	"use_memcache_client": False,
+	"use_memcache_client": True,
 }

--- a/src/viur/datastore/errors.py
+++ b/src/viur/datastore/errors.py
@@ -168,7 +168,7 @@ CANONICAL_ERROR_CODE_MAP = {
 }
 
 
-def is_viur_datastore_request_ok(req: requests.Request) -> bool:
+def is_viur_datastore_request_ok(req: requests.Response) -> bool:
 	"""This small helper function raise an appropriate exception class for errors happened talking to google datastore.
 
 	It returns True if everything is ok, otherwise raises.

--- a/src/viur/datastore/transport.pyx
+++ b/src/viur/datastore/transport.pyx
@@ -601,11 +601,11 @@ def Get(keys: Union[Key, List[Key]]) -> Union[None, Entity, List[Entity]]:
 		if conf["use_memcache_client"]:
 			res_from_cache = cache.get(keys_for_request)
 			# Convert the keys back to "class" representation
-			res_from_cache = {Key.from_legacy_urlsafe(key): value for key, value in
-							  res_from_cache.items()}
+			res_from_cache = {Key.from_legacy_urlsafe(key): value 
+			                  for key, value in res_from_cache.items()}
 
 		missing_keys = [key for key in keys_for_request if key not in res_from_cache.keys()]
-		if len(missing_keys)== 0:
+		if not missing_keys:
 			# We had all keys in the memcache we can fetch the next batch now.
 			keys = keys[300:]
 			continue
@@ -633,11 +633,11 @@ def Get(keys: Union[Key, List[Key]]) -> Union[None, Entity, List[Entity]]:
 
 		if (element.at_pointer("/deferred").error() == SUCCESS):
 			deferred_keys = toPythonStructure(element.at_key("deferred"))
-			missing_keys_paths=[keyToPath(key) for key in missing_keys]
+			missing_keys_paths = [keyToPath(key) for key in missing_keys]
 			keys = keys[300:]
-			for i,deferred_key in enumerate(deferred_keys):
+			for i, deferred_key in enumerate(deferred_keys):
 				if deferred_key in missing_keys_paths:
-					keys.insert(0,missing_keys[i])
+					keys.insert(0, missing_keys[i])
 
 		else:
 			keys = keys[300:]
@@ -703,7 +703,7 @@ def Delete(keys: Union[Key, List[Key], Entity, List[Entity]]) -> None:
 		if arrayElem.size() != abs(len(keys)):
 			print(req.content)
 			raise ValueError("Invalid number of mutation-results received")
-	if conf["use_memcache_client"] :
+	if conf["use_memcache_client"]:
 		cache.delete([str(key) for key in keys])
 
 def Put(entities: Union[Entity, List[Entity]]) -> Union[Entity, List[Entity]]:

--- a/src/viur/datastore/transport.pyx
+++ b/src/viur/datastore/transport.pyx
@@ -601,7 +601,7 @@ def Get(keys: Union[Key, List[Key]]) -> Union[None, Entity, List[Entity]]:
 		if conf["use_memcache_client"]:
 			res_from_cache = cache.get(keys_for_request)
 			# Convert the keys back to "class" representation
-			res_from_cache = {Key.from_legacy_urlsafe(key): value 
+			res_from_cache = {Key.from_legacy_urlsafe(key): value
 			                  for key, value in res_from_cache.items()}
 
 		missing_keys = [key for key in keys_for_request if key not in res_from_cache.keys()]
@@ -765,7 +765,7 @@ def Put(entities: Union[Entity, List[Entity]]) -> Union[Entity, List[Entity]]:
 			preincrement(arrayIt)
 			idx += 1
 		if conf["use_memcache_client"]:
-			# iter over all entities and write them to the chache
+			# iter over all entities and write them to the cache
 			cache.set(entities)
 	return entities
 

--- a/src/viur/datastore/transport.pyx
+++ b/src/viur/datastore/transport.pyx
@@ -598,7 +598,7 @@ def Get(keys: Union[Key, List[Key]]) -> Union[None, Entity, List[Entity]]:
 	while keys:
 		keys_for_request = keys[:300]
 
-		if conf["use_memcache_client"]:
+		if conf["memcache_client"] is not None:
 			res_from_cache = cache.get(keys_for_request)
 			# Convert the keys back to "class" representation
 			res_from_cache = {Key.from_legacy_urlsafe(key): value
@@ -642,7 +642,7 @@ def Get(keys: Union[Key, List[Key]]) -> Union[None, Entity, List[Entity]]:
 		else:
 			keys = keys[300:]
 	res = res_from_db | res_from_cache
-	if conf["use_memcache_client"]:
+	if conf["memcache_client"] is not None:
 		# Cache only the entities form db.
 		cache.put({str(key): value for key, value in res_from_db.items()})
 
@@ -703,7 +703,7 @@ def Delete(keys: Union[Key, List[Key], Entity, List[Entity]]) -> None:
 		if arrayElem.size() != abs(len(keys)):
 			print(req.content)
 			raise ValueError("Invalid number of mutation-results received")
-	if conf["use_memcache_client"]:
+	if conf["memcache_client"] is not None:
 		cache.delete([str(key) for key in keys])
 
 def Put(entities: Union[Entity, List[Entity]]) -> Union[Entity, List[Entity]]:
@@ -764,7 +764,7 @@ def Put(entities: Union[Entity, List[Entity]]) -> Union[Entity, List[Entity]]:
 			entities[idx].version = toPyStr(innerArrayElem.at_key("version").get_string())
 			preincrement(arrayIt)
 			idx += 1
-		if conf["use_memcache_client"]:
+		if conf["memcache_client"] is not None:
 			# iter over all entities and write them to the cache
 			cache.put(entities)
 	return entities

--- a/src/viur/datastore/transport.pyx
+++ b/src/viur/datastore/transport.pyx
@@ -644,7 +644,7 @@ def Get(keys: Union[Key, List[Key]]) -> Union[None, Entity, List[Entity]]:
 	res = res_from_db | res_from_cache
 	if conf["use_memcache_client"]:
 		# Cache only the entities form db.
-		cache.set({str(key): value for key, value in res_from_db.items()})
+		cache.put({str(key): value for key, value in res_from_db.items()})
 
 	if not isMulti:
 		return res.get(untouched_keys[0])
@@ -766,7 +766,7 @@ def Put(entities: Union[Entity, List[Entity]]) -> Union[Entity, List[Entity]]:
 			idx += 1
 		if conf["use_memcache_client"]:
 			# iter over all entities and write them to the cache
-			cache.set(entities)
+			cache.put(entities)
 	return entities
 
 


### PR DESCRIPTION
This PR implements the memcache for viur-datastore. 
TThe idea behind this is to make queries that often run over db.Get more performant. For example, with each request the session is loaded which can now be cached in memcache. This makes the loading up to **7-15** times faster

Todos:

- [x] Make a PR for the core to add `appengine-python-standard` to  the dependencies and wirte a wrapper for the main app.
- [x] Make a PR for the viur-base for the app.yml
- [ ] Make  a PR for the app_server to support the local development.