### PR TITLE
Add AbortedError in RunInTransaction

### DIFF
--- a/src/viur/datastore/transport.pyx
+++ b/src/viur/datastore/transport.pyx
@@ -826,7 +826,7 @@ def RunInTransaction(callback: callable, *args, **kwargs) -> Any:
 						return res
 				finally:  # Ensure, currentTransaction is always set back to none
 					currentTransaction.set(None)
-		except CollisionError:  # Got a collision; retry the entire transaction
+		except CollisionError, AbortedError:  # Got a collision or is aborted; retry the entire transaction
 			sleep(2 ** exponential_backoff)
 	raise CollisionError("All retries are exhausted for this transaction") # If we made it here, all tries are exhausted
 


### PR DESCRIPTION
Add `AbortedError` in the `except` so it can be retry.



https://cloud.google.com/datastore/docs/concepts/errors#error_codes


**For requests that are part of a [transactional](https://cloud.google.com/datastore/docs/concepts/transactions) commit:
Retry the entire transaction or structure your entities to reduce contention.**

Response form google datastore:
![image](https://github.com/viur-framework/viur-datastore/assets/47318461/15ba70bb-6641-410f-88fa-81b3f158548e)


