### PR TITLE
Parse subkey to int if only digits

### DIFF
--- a/src/viur/datastore/types.py
+++ b/src/viur/datastore/types.py
@@ -74,8 +74,10 @@ class Key:
 		if isinstance(subKey, int):
 			self.id = subKey
 		elif isinstance(subKey, str):
-			assert not subKey.isdigit(), "Digit-Only string keys are not permitted"
-			self.name = subKey
+			if subKey.isdigit():
+				self.id = int(subKey)
+			else:
+				self.name = subKey
 		self.parent = parent
 
 	@property

--- a/tests/basic.py
+++ b/tests/basic.py
@@ -119,5 +119,28 @@ class BasicFunctionTest(BaseTestClass):
 		self.assertEqual(datastore.Count(testKindName), 10)
 		self.assertEqual(datastore.Count(testKindName, 4), 4)
 
+	def test_key_init(self) -> None:
+		key = datastore.Key(testKindName, 42)
+		self.assertIsInstance(key.id, int)
+		self.assertEqual(key.id, 42)
+		self.assertIsNone(key.name)
+		self.assertIsNone(key.parent)
+
+		key = datastore.Key(testKindName, "1337")
+		self.assertIsInstance(key.id, int)
+		self.assertEqual(key.id, 1337)
+		self.assertIsNone(key.name)
+		self.assertIsNone(key.parent)
+
+		key = datastore.Key(testKindName, "foo")
+		self.assertEqual(key.name, "foo")
+		self.assertIsNone(key.id)
+		self.assertIsNone(key.parent)
+
+		parent_key = datastore.Key(testKindName, "foo")
+		key = datastore.Key(testKindName, "bar", parent_key)
+		self.assertEqual(key.name, "bar")
+		self.assertEqual(key.parent, parent_key)
+
 if __name__ == '__main__':
 	unittest.main()

--- a/tests/queryvalues.py
+++ b/tests/queryvalues.py
@@ -138,12 +138,18 @@ class QueryValuesTest(BaseTestClass):
 		self.assertTrue(len(datastore.Query(testKindName).filter("nullVal =", None).run(100)) == 1)
 
 	def test_key_value(self):
-		keyList = [datastore.Key(testKindName, 1234), datastore.Key(testKindName, 5678), datastore.Key(testKindName, "teststr"), datastore.Key(testKindName, "teststr", parent=datastore.Key(testKindName, "teststr"))]
-		for keyVal in keyList:
+		key_list = [datastore.Key(testKindName, 1234),
+					datastore.Key(testKindName, 5678),
+					datastore.Key(testKindName, "teststr"),
+					datastore.Key(testKindName, "teststr", parent=datastore.Key(testKindName, "teststr")),
+					datastore.Key(testKindName, "42"),  # String with only digits (#33)
+					datastore.Key(testKindName, "1337", parent=datastore.Key(testKindName, "13")),
+					]
+		for keyVal in key_list:
 			e = datastore.Entity(datastore.Key(testKindName))
 			e["keyVal"] = keyVal
 			datastore.Put(e)
-		for keyVal in keyList:
+		for keyVal in key_list:
 			self.assertTrue(len(datastore.Query(testKindName).filter("keyVal =", keyVal).run(100)) == 1)
 		# FIXME: HAS_ANCESTOR is not yet implemented
 


### PR DESCRIPTION
Thix fix https://github.com/viur-framework/viur-core/issues/836. Now if the `subkey` is from type `string` but only contains digits the `subkey` is parsed to in and set to id.