### PR TITLE
chore: decrease minimal required python version to 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
 	url="https://github.com/viur-framework/viur-datastore",
 	packages=['viur.datastore'],
 	package_dir={'': 'src'},
-	python_requires=">=3.11",
+	python_requires=">=3.10",
 	cmdclass={'build_ext': build_ext},
 	ext_modules=cythonize([Extension("viur.datastore.transport", ["src/viur/datastore/transport.pyx"], language="c++", extra_compile_args=["-std=c++11"])]),
 	classifiers=[


### PR DESCRIPTION
Was increased in https://github.com/viur-framework/viur-datastore/commit/33e1f49d5b66af2f0cec17f4e60e069ba2b4eaee but this is incompatible for the viur-core