### PR TITLE
fix: Refuse `Get` in complete keys

### DIFF
--- a/src/viur/datastore/transport.pyx
+++ b/src/viur/datastore/transport.pyx
@@ -581,6 +581,8 @@ def Get(keys: Union[Key, List[Key]]) -> Union[None, Entity, List[Entity]]:
     if isinstance(keys, Key):
         keys = [keys]
         isMulti = False
+    if any(key.is_partial or key.kind is None for key in keys):
+        raise InvalidArgumentError("Keys must not be partial or kind-less")
     accessLog = currentDbAccessLog.get()
     if isinstance(accessLog, set):
         accessLog.update(set(keys))

--- a/tests/basic.py
+++ b/tests/basic.py
@@ -1,10 +1,12 @@
 import unittest
+
 from viur import datastore
-from .base import BaseTestClass, datastoreSampleValues, viurTypeToGoogleType, testKindName
+from .base import BaseTestClass, datastoreSampleValues, testKindName, viurTypeToGoogleType
 
 """
 	This test-set ensures that basic operations as get, put and delete work as expected
 """
+
 
 class BasicFunctionTest(BaseTestClass):
 
@@ -27,6 +29,17 @@ class BasicFunctionTest(BaseTestClass):
 		self.datastoreClient.put(e)  # Create the entity
 		self.assertTrue(self.datastoreClient.get(self.datastoreClient.key(testKindName, "test-entity")) is not None)
 		self.assertTrue(datastore.Get(datastore.Key(testKindName, "test-entity")) is not None)
+
+	def test_get_partial_key(self):
+		"""
+		Ensure we refuse invalid keys in Get before fetching
+		"""
+		with self.assertRaises(datastore.InvalidArgumentError):
+			# partial (no id_or_name) key
+			_ = datastore.Get(datastore.Key(testKindName))
+		with self.assertRaises(datastore.InvalidArgumentError):
+			# kind-less keyy
+			_ = datastore.Get(datastore.Key(None, "foo"))  # noqa
 
 	def test_delete(self):
 		"""
@@ -86,7 +99,7 @@ class BasicFunctionTest(BaseTestClass):
 			The indexed/unindexed flag is handled differently than all other datatypes.
 			Ensure, we can set a list to un-indexed.
 		"""
-		testList = ["a"*600, "b"*600]
+		testList = ["a" * 600, "b" * 600]
 		entity = datastore.Entity(datastore.Key(testKindName, "test-entity"))
 		entity["testlist"] = testList
 		entity.exclude_from_indexes.add("testlist")
@@ -100,7 +113,7 @@ class BasicFunctionTest(BaseTestClass):
 			The indexed/unindexed flag is handled differently than all other datatypes.
 			Ensure, we can store an indexed list.
 		"""
-		testList = ["a"*300, "b"*300]
+		testList = ["a" * 300, "b" * 300]
 		entity = datastore.Entity(datastore.Key(testKindName, "test-entity"))
 		entity["testlist"] = testList
 		datastore.Put(entity)
@@ -141,6 +154,7 @@ class BasicFunctionTest(BaseTestClass):
 		key = datastore.Key(testKindName, "bar", parent_key)
 		self.assertEqual(key.name, "bar")
 		self.assertEqual(key.parent, parent_key)
+
 
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
After getting a bunch of `AssertionError`s like described in #34, I added and wrapper around `db.Get()` with argument logging. I found out there's some code which tries to fetch incomplete keys. The datastore does not valide them and the request fails. Probably we could have saved a lot of time if we had already merged https://github.com/viur-framework/viur-datastore/pull/37. 


![image](https://github.com/viur-framework/viur-datastore/assets/10272292/3d7e0daf-aea7-4fd8-b684-f930931049cf)





this fixes one possible case of #34